### PR TITLE
week2: assignment

### DIFF
--- a/springstudy/src/main/java/com/likelion/springstudy/domain/entity/BoxEntity.java
+++ b/springstudy/src/main/java/com/likelion/springstudy/domain/entity/BoxEntity.java
@@ -1,0 +1,27 @@
+package com.likelion.springstudy.domain.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter @Setter
+@Table(name = "box")
+public class BoxEntity {
+    @Id @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToOne(mappedBy = "box")
+    private MemberEntity member;
+
+    @OneToMany(mappedBy = "box")
+    private List<LetterEntity> letters;
+}

--- a/springstudy/src/main/java/com/likelion/springstudy/domain/entity/LetterEntity.java
+++ b/springstudy/src/main/java/com/likelion/springstudy/domain/entity/LetterEntity.java
@@ -1,0 +1,43 @@
+package com.likelion.springstudy.domain.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter @Setter
+@Table(name = "letter")
+public class LetterEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false, name = "photo_url")
+    private String photoUrl;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "box_id")
+    private BoxEntity box;
+
+    @ManyToOne
+    private MemberEntity sender;
+}

--- a/springstudy/src/main/java/com/likelion/springstudy/domain/entity/MemberEntity.java
+++ b/springstudy/src/main/java/com/likelion/springstudy/domain/entity/MemberEntity.java
@@ -2,8 +2,13 @@ package com.likelion.springstudy.domain.entity;
 
 
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -14,14 +19,34 @@ public class MemberEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 20)
     private String username;
 
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 20)
     private String nickname;
+
+    @CreatedDate
+    @Column(nullable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false, name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(nullable = true, name = "is_deleted")
+    private Boolean isDeleted;
+
+    @Column(nullable = true, name = "deleted_at")
+    private LocalDate deleteAt;
+
+    @OneToOne(mappedBy = "member")
+    private BoxEntity box;
+
+    @OneToMany(mappedBy = "sender")
+    private List<LetterEntity> lettersSent;
 
     @Builder
     public MemberEntity(Long id, String username, String password, String nickname) {


### PR DESCRIPTION
1. 과제 ERD에는 없긴 하지만 `LetterEntity`에 sender가 있으면 좋을 것 같아 추가함

2-1. `@OneToOne + @JoinColumn(name = ...)` : FK를 지정할 때 사용됨. 이 FK는 외래키 관계를 설정하는 엔티티의 테이블에 추가된다.
예를 들어 다음 코드에서 `address_id`는 FK 컬럼의 이름이다.
```
public class Member {
    @OneToOne
    @JoinColumn(name = "address_id")
    private Address address;
}
```
2-2. `@OneToOne(mappedBy = ...)`: 어떤 엔티티 클래스가 일대일 관계를 가지는지 정의하며, 어떤 필드가 관계의 주인인지 지정한다.
```
public class Address {
    @OneToOne(mappedBy = "address")
    private Member member;
}
```
-> Address와 Member는 일대일 관계이고, Address 엔티티의 member 필드가 관계의 주인이 된다. (Member 테이블에는 FK 컬럼이 추가되지 않음)

정리하자면
- `@JoinColumn`: 관계의 주인이 사용하는 어노테이션. FK 이름을 지정할 수 있음.
- `@OneToOne(mappedBy)`: 관계의 주인이 아닌 엔티티에서 사용하는 어노테이션.
둘 중 선택해서 사용하면 될 것 같다
